### PR TITLE
Make the db update a bit smoother

### DIFF
--- a/install-host/update-all.sh
+++ b/install-host/update-all.sh
@@ -18,6 +18,12 @@ export PATH=/usr/local/go/bin:/root/go/bin:$PATH
 ./cvedb.sh --nvd
 
 # Now update production database
-cp *.sqlite3 /srv/vuls/db/
+mkdir -p /srv/vuls/db-new/
+mv *.sqlite3 /srv/vuls/db-new/
+systemctl stop vuls
+mv /srv/vuls/db /srv/vuls/db-old
+mv /srv/vuls/db-new /srv/vuls/db
 # No reload
-systemctl restart vuls
+systemctl start vuls
+# Clean
+rm -r /srv/vuls/db-old


### PR DESCRIPTION
Currently, we sometimes get:

```
Failed to detect CVE with OVAL: Failed to newOvalDB. err: Failed to init OVAL DB. DB Path: /srv/vuls/db/oval.sqlite3, err: Failed to migrate db. err: Failed to migrate. err: database disk image is malformed (11)
```

in our monitoring request, when the database is being replaced. Take advantage of our two-step update to lower the unavailability to a minimum.